### PR TITLE
`ensureCapacity` does not reserve adequate capacity

### DIFF
--- a/core/src/main/java/gnu/trove/THash.java
+++ b/core/src/main/java/gnu/trove/THash.java
@@ -146,8 +146,7 @@ public abstract class THash implements Cloneable {
      */
     public void ensureCapacity(int desiredCapacity) {
         if (desiredCapacity > (_maxSize - size())) {
-            rehash(PrimeFinder.nextPrime((int) (desiredCapacity + size() /
-                    _loadFactor) + 2));
+            rehash(PrimeFinder.nextPrime((int) ((desiredCapacity + size()) / _loadFactor) + 2));
             computeMaxSize(capacity());
         }
     }


### PR DESCRIPTION
`ensureCapacity` fails to reserve enough space for the passed number of elements—effectively only `desiredCapacity * _loadFactor` is reserved, so by default only enough space for about 80% of the elements.
For instance, when joining two distinct sets via `addAll`, this regularly causes the receiving set to be rehashed multiple times:
<img width="610" alt="addAll may cause multiple rehashes" src="https://user-images.githubusercontent.com/406830/52712636-833daa80-2f95-11e9-8a75-9ce675dab2f1.png">

I propose to scale the `desiredCapacity` by the inverse of the `_loadFactor` as well.

This seems to match what's happening upstream:
https://bitbucket.org/trove4j/trove/src/ffd7590dce7a205fb886aae4b7c0df01bb8ffa2f/core/src/main/java/gnu/trove/impl/hash/THash.java?at=master&fileviewer=file-view-default#THash.java-200