### PR TITLE
Disable placing null elements into THashSet

### DIFF
--- a/core/src/main/java/gnu/trove/THashSet.java
+++ b/core/src/main/java/gnu/trove/THashSet.java
@@ -134,6 +134,9 @@ public class THashSet<E> extends TObjectHash<E> implements Set<E> {
      * @return true if the set was modified by the add operation
      */
     public boolean add(E obj) {
+        if (obj == null) {
+            throw new NullPointerException("Null elements are not allowed in THashSet");
+        }
         int index = insertionIndex(obj);
 
         if (index < 0) {


### PR DESCRIPTION
They are not properly supported. After placing such an element the THashSet becomes broken. E.g.:

```
THashSet<Object> set = new THashSet<>();
set.add(null);
System.out.println(set.size()); // prints 1
System.out.println(Arrays.toString(set.toArray(new Object[0]))); // throws NoSuchElementException
```