### PR TITLE
Add implementations of equals()/hashCode() for views of THashMap

### DIFF
--- a/core/src/main/java/gnu/trove/THashMap.java
+++ b/core/src/main/java/gnu/trove/THashMap.java
@@ -593,7 +593,7 @@ public class THashMap<K,V> extends TObjectHash<K> implements Map<K,V> {
         }
     }
 
-    private abstract class MapBackedView<E> implements Set<E> {
+    private abstract class MapBackedView<E> extends AbstractSet<E> {
         MapBackedView() {
         }
 
@@ -742,6 +742,32 @@ public class THashMap<K,V> extends TObjectHash<K> implements Map<K,V> {
             val = o;            // update this entry's value, in case
                                 // setValue is called again
             return prev;
+        }
+
+
+        @Override
+        public final boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            }
+            if (o instanceof Map.Entry) {
+                Map.Entry<?, ?> otherEntry = (Map.Entry<?, ?>) o;
+                Object otherKey = otherEntry.getKey();
+                Object otherValue = otherEntry.getValue();
+                //noinspection unchecked
+                if (!(key == otherKey || key != null && _hashingStrategy.equals(key, (K) otherKey))) {
+                    return false;
+                }
+                return val == otherValue || (val != null && val.equals(otherValue));
+            }
+            return false;
+        }
+
+        @Override
+        public final int hashCode() {
+            HashProcedure hashProcedure = new HashProcedure();
+            hashProcedure.execute(key, val);
+            return hashProcedure.getHashCode();
         }
     }
 

--- a/core/src/test/java/gnu/trove/MapTest.java
+++ b/core/src/test/java/gnu/trove/MapTest.java
@@ -12,6 +12,7 @@ public class MapTest {
     public static void main(String[] args) {
         testTIntObjectHashMap();
         testTHashMap();
+        testTHashMapViewsEquality();
         testClone();
     }
 
@@ -352,6 +353,31 @@ public class MapTest {
         assertEquals(6, map._size);
         assertEquals(DEFAULT_LOAD_FACTOR, map._loadFactor);
         assertEquals((int) (map.capacity() * map._loadFactor), map._maxSize);
+    }
+
+    public static void testTHashMapViewsEquality() {
+      THashMap<String, Integer> oneMap = new THashMap<String, Integer>();
+      THashMap<String, Integer> twoMap = new THashMap<String, Integer>();
+
+      for (int i = 0; i < 10; i++) {
+        String oneKey = String.valueOf(i);
+        oneMap.put(oneKey, i);
+
+        String twoKey = String.valueOf(9 - i);
+        twoMap.put(twoKey, 9 - i);
+      }
+
+      assertEquals(oneMap, twoMap);
+      assertEquals(oneMap.hashCode(), twoMap.hashCode());
+
+      assertEquals(oneMap.keySet(), twoMap.keySet());
+      assertEquals(oneMap.keySet().hashCode(), twoMap.keySet().hashCode());
+
+      assertEquals(oneMap.values(), twoMap.values());
+      assertEquals(oneMap.values().hashCode(), twoMap.values().hashCode());
+
+      assertEquals(oneMap.entrySet(), twoMap.entrySet());
+      assertEquals(oneMap.entrySet().hashCode(), twoMap.entrySet().hashCode());
     }
 
     public static void testClone() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-projectVersion=1.0.20200330
+projectVersion=1.0.20200403

--- a/trove4j_changes.txt
+++ b/trove4j_changes.txt
@@ -1,3 +1,6 @@
+Date: 03 March 2020
+   Changed classes: THashMap.java
+     Add implementations of equals()/hashCode() for views of THashMap: keySet(), values(), entrySet().
 Date: 13 May 2019
    Changes classes: PrimeFinder.java
      Use already sorted array instead of sorting primes in the class initalizer to avoid exposing not-yet-sorted primes.


### PR DESCRIPTION
`THashMap.keySet()` appeared to miss implementation of `equals()/hashCode()`.
I hit a bug comparing keys of two maps:
```
Map<K, V> one
Map<K, V> two
// This assertion fails if one or two is THashMap.
assertEquals(one.keySet(), two.keySet());
```